### PR TITLE
Add support for S3-compatible services

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ jobs can be set in one file.
    ZFS filesystem.
 #### region : str, default: us-east-1
    S3 region.
-#### endpoint : str
+#### endpoint : str, optional
    S3 endpoint - for S3 compatible services
 #### cron : str, optional
    Cron schedule. Example: `* 0 * * *`

--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ jobs can be set in one file.
    ZFS filesystem.
 #### region : str, default: us-east-1
    S3 region.
+#### endpoint : str
+   S3 endpoint - for S3 compatible services
 #### cron : str, optional
    Cron schedule. Example: `* 0 * * *`
 #### max_snapshots : int, optional
@@ -99,6 +101,23 @@ max_backups = 7
 Filesystem is backed up at 02:00 daily. Only the most recent 7 snapshots
 are kept. The oldest backup without dependents is removed once there are
 more than 7 backups.
+
+#### Backblaze B2 S3-compatible endpoint, full backups
+```ini
+[DEFAULT]
+bucket_name = BUCKET_NAME
+region = eu-central-003
+access_key = ACCESS_KEY
+secret_key = SECRET_KEY
+storage_class = STANDARD
+endpoint = https://s3.eu-central-003.backblazeb2.com
+
+[pool/filesystem]
+cron = 0 2 * * *
+max_snapshots = 7
+max_incremental_backups_per_full = 6
+max_backups = 7
+```
 
 ##### Structure
 full backup (f), incremental backup (i)

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ jobs can be set in one file.
 #### region : str, default: us-east-1
    S3 region.
 #### endpoint : str, optional
-   S3 endpoint - for S3 compatible services
+   S3 endpoint for alternative services
 #### cron : str, optional
    Cron schedule. Example: `* 0 * * *`
 #### max_snapshots : int, optional

--- a/zfs_uploader/config.py
+++ b/zfs_uploader/config.py
@@ -66,6 +66,7 @@ class Config:
                         secret_key,
                         filesystem,
                         region=v.get('region') or default.get('region'),
+                        endpoint=v.get('endpoint') or default.get('endpoint'),
                         cron=cron_dict,
                         max_snapshots=(v.getint('max_snapshots') or
                                        default.getint('max_snapshots')),

--- a/zfs_uploader/job.py
+++ b/zfs_uploader/job.py
@@ -39,6 +39,11 @@ class ZFSjob:
         return self._region
 
     @property
+    def endpoint(self):
+        """ S3 Endpoint. """
+        return self._endpoint
+
+    @property
     def access_key(self):
         """ S3 access key. """
         return self._access_key
@@ -111,6 +116,8 @@ class ZFSjob:
             ZFS filesystem.
         region : str, default: us-east-1
             S3 region.
+        endpoint : str, optional
+            S3 endpoint for alternative services
         cron : str, optional
             Cron schedule. Example: `* 0 * * *`
         max_snapshots : int, optional
@@ -121,7 +128,6 @@ class ZFSjob:
             Maximum number of incremental backups per full backup.
         storage_class : str, default: STANDARD
             S3 storage class.
-        endpoint : str
 
         """
         self._bucket_name = bucket_name

--- a/zfs_uploader/job.py
+++ b/zfs_uploader/job.py
@@ -95,7 +95,8 @@ class ZFSjob:
 
     def __init__(self, bucket_name, access_key, secret_key, filesystem,
                  region=None, cron=None, max_snapshots=None, max_backups=None,
-                 max_incremental_backups_per_full=None, storage_class=None):
+                 max_incremental_backups_per_full=None, storage_class=None,
+                 endpoint=None):
         """ Create ZFSjob object.
 
         Parameters
@@ -120,6 +121,7 @@ class ZFSjob:
             Maximum number of incremental backups per full backup.
         storage_class : str, default: STANDARD
             S3 storage class.
+        endpoint : str
 
         """
         self._bucket_name = bucket_name
@@ -127,11 +129,13 @@ class ZFSjob:
         self._access_key = access_key
         self._secret_key = secret_key
         self._filesystem = filesystem
+        self._endpoint = endpoint
 
         self._s3 = boto3.resource(service_name='s3',
                                   region_name=self._region,
                                   aws_access_key_id=self._access_key,
-                                  aws_secret_access_key=self._secret_key)
+                                  aws_secret_access_key=self._secret_key,
+                                  endpoint_url=endpoint)
         self._bucket = self._s3.Bucket(self._bucket_name)
         self._backup_db = BackupDB(self._bucket, self._filesystem)
         self._snapshot_db = SnapshotDB(self._filesystem)


### PR DESCRIPTION
This PR adds support for alternative s3 endpoints, which in turn gives support for S3-compatible services.

I'm using this for backing up to Backblaze B2.