### PR TITLE
Set `misfire_grace_time` in `job_defaults`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.1](https://github.com/ddebeau/zfs_uploader/compare/0.7.0...0.7.1) 2022-02-08
+
+### Fixed
+
+- Fix `misfire_grace_time` issue where a job could get skipped if it was 
+  scheduled too close to another job.
+[#56](https://github.com/ddebeau/zfs_uploader/issues/56)
+
 ## [0.7.0](https://github.com/ddebeau/zfs_uploader/compare/0.6.0...0.7.0) 2022-01-27
 
 ### Added

--- a/zfs_uploader/__init__.py
+++ b/zfs_uploader/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.7.0'
+__version__ = '0.7.1'
 
 BACKUP_DB_FILE = 'backup.db'
 DATETIME_FORMAT = '%Y%m%d_%H%M%S'

--- a/zfs_uploader/__main__.py
+++ b/zfs_uploader/__main__.py
@@ -52,7 +52,8 @@ def backup(ctx):
 
     config = Config(config_path)
     scheduler = BlockingScheduler(
-        executors={'default': ThreadPoolExecutor(max_workers=1)}
+        executors={'default': ThreadPoolExecutor(max_workers=1)},
+        job_defaults={'misfire_grace_time': None}
     )
 
     for job in config.jobs.values():


### PR DESCRIPTION
Closes: https://github.com/ddebeau/zfs_uploader/issues/56

Fix has been tested in production.