### PR TITLE
Fix unencrypted incremental streams

### DIFF
--- a/zfs_uploader/zfs.py
+++ b/zfs_uploader/zfs.py
@@ -84,7 +84,7 @@ def open_snapshot_stream(filesystem, snapshot_name, mode):
 
 def open_snapshot_stream_inc(filesystem, snapshot_name_1, snapshot_name_2):
     """ Open incremental snapshot read stream. """
-    cmd = ['zfs', 'send', '-i', f'{filesystem}@{snapshot_name_1}',
+    cmd = ['zfs', 'send', '-w', '-i', f'{filesystem}@{snapshot_name_1}',
            f'{filesystem}@{snapshot_name_2}']
     return subprocess.Popen(cmd, stdout=subprocess.PIPE,
                             stderr=subprocess.PIPE)


### PR DESCRIPTION
Add the raw flag to incremental ZFS send commands too.
Missed with #46.