### PR TITLE
Fix encrypted dataset restore and make backup cron setting optional 

### DIFF
--- a/zfs_uploader/__main__.py
+++ b/zfs_uploader/__main__.py
@@ -57,13 +57,20 @@ def backup(ctx):
     )
 
     for job in config.jobs.values():
-        logger.info(f'filesystem={job.filesystem} '
-                    f'cron="{job.cron}" '
-                    'msg="Adding job."')
-        scheduler.add_job(job.start, 'cron', **job.cron, coalesce=True)
+        if job.cron:
+            logger.info(f'filesystem={job.filesystem} '
+                        f'cron="{job.cron}" '
+                        'msg="Adding job."')
+            scheduler.add_job(job.start, 'cron', **job.cron, coalesce=True)
+        else:
+            # Run the job without the scheduler and make the cron config optional
+            logger.info(f'filesystem={job.filesystem}'
+                        'msg="Running job."')
+            job.start()
 
     try:
-        scheduler.start()
+        if len(scheduler.get_jobs()) > 0:
+            scheduler.start()
     except (KeyboardInterrupt, SystemExit):
         pass
 

--- a/zfs_uploader/job.py
+++ b/zfs_uploader/job.py
@@ -250,11 +250,6 @@ class ZFSjob:
         backup_type = backup.backup_type
         s3_key = backup.s3_key
 
-        if filesystem:
-            out = create_filesystem(filesystem)
-            if out.returncode:
-                raise ZFSError(out.stderr)
-
         if backup_type == 'full':
             if backup_time in snapshots and filesystem is None:
                 self._logger.info(f'filesystem={self.filesystem} '

--- a/zfs_uploader/zfs.py
+++ b/zfs_uploader/zfs.py
@@ -74,7 +74,7 @@ def open_snapshot_stream(filesystem, snapshot_name, mode):
         return subprocess.Popen(cmd, stdout=subprocess.PIPE,
                                 stderr=subprocess.PIPE)
     elif mode == 'w':
-        cmd = ['zfs', 'receive', '-F', f'{filesystem}@{snapshot_name}']
+        cmd = ['zfs', 'receive', f'{filesystem}@{snapshot_name}']
         return subprocess.Popen(cmd, stdin=subprocess.PIPE,
                                 stdout=subprocess.PIPE,
                                 stderr=subprocess.PIPE)


### PR DESCRIPTION
- As stated in the docs, the cron config should be optional. When not providing a cron config, it was crashing on backup as its dereferenced in the add_job call. 

- The tool was correctly using the raw method to upload the send binary but on receive / restore, it was first creating a datastore and then forcing a rewrite with the -F flag. This poses a problem on encrypted datasets as you can't restore with -F. See https://github.com/openzfs/zfs/issues/6793 for more information. This change removes the -F but also does not create the dataset, which should be fine as receive would do that anyways. Tested on encrypted datasets and now its working