### PR TITLE
Add encrypted file system job tests

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,9 +7,9 @@ jobs:
     environment: release
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Install Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.x
     - name: Install dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Install Python 3.6
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.6
     - name: Run Flake8

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     environment: test
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Install Python 3.6
       uses: actions/setup-python@v2
       with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Fix bug where `zfsup restore` fails when the filesystem is encrypted
+[#69](https://github.com/ddebeau/zfs_uploader/pull/69)
+
 ## [0.8.0](https://github.com/ddebeau/zfs_uploader/compare/0.7.2...0.8.0) 2022-03-28
 
 ### Added

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -4,7 +4,7 @@ import warnings
 
 from zfs_uploader.config import Config
 from zfs_uploader.zfs import (create_filesystem, destroy_filesystem, load_key,
-                              SUBPROCESS_KWARGS)
+                              mount_filesystem, SUBPROCESS_KWARGS)
 
 
 class JobTestsBase:
@@ -83,6 +83,9 @@ class JobTestsBase:
             out = load_key(self.job.filesystem, 'file:///test_key')
             self.assertEqual(0, out.returncode, msg=out.stderr)
 
+            out = mount_filesystem(self.job.filesystem)
+            self.assertEqual(0, out.returncode, msg=out.stderr)
+
         # Then
         with open(self.test_file, 'r') as f:
             out = f.read()
@@ -104,6 +107,9 @@ class JobTestsBase:
         self.job.restore()
         if self.encrypted_test:
             out = load_key(self.job.filesystem, 'file:///test_key')
+            self.assertEqual(0, out.returncode, msg=out.stderr)
+
+            out = mount_filesystem(self.job.filesystem)
             self.assertEqual(0, out.returncode, msg=out.stderr)
 
         # Then
@@ -130,6 +136,9 @@ class JobTestsBase:
             out = load_key(self.job.filesystem, 'file:///test_key')
             self.assertEqual(0, out.returncode, msg=out.stderr)
 
+            out = mount_filesystem(self.job.filesystem)
+            self.assertEqual(0, out.returncode, msg=out.stderr)
+
         # Then
         with open(self.test_file, 'r') as f:
             out = f.read()
@@ -144,6 +153,9 @@ class JobTestsBase:
         self.job.restore(filesystem=self.filesystem_2)
         if self.encrypted_test:
             out = load_key(self.filesystem_2, 'file:///test_key')
+            self.assertEqual(0, out.returncode, msg=out.stderr)
+
+            out = mount_filesystem(self.job.filesystem)
             self.assertEqual(0, out.returncode, msg=out.stderr)
 
         # Then

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -3,8 +3,9 @@ import subprocess
 import warnings
 
 from zfs_uploader.config import Config
-from zfs_uploader.zfs import (create_filesystem, destroy_filesystem, load_key,
-                              mount_filesystem, SUBPROCESS_KWARGS)
+from zfs_uploader.zfs import (create_filesystem, destroy_filesystem,
+                              destroy_snapshot, load_key, mount_filesystem,
+                              SUBPROCESS_KWARGS)
 
 
 class JobTestsBase:
@@ -96,6 +97,10 @@ class JobTestsBase:
         # Given
         self.job.start()
 
+        snapshots = self.job._snapshot_db.get_snapshots()
+        out = destroy_snapshot(self.job.filesystem, snapshots[-1])
+        self.assertEqual(0, out.returncode, msg=out.stderr)
+
         with open(self.test_file, 'w') as f:
             f.write('new data')
 
@@ -141,6 +146,10 @@ class JobTestsBase:
         with open(self.test_file, 'a') as f:
             f.write('append')
         self.job.start()
+
+        snapshots = self.job._snapshot_db.get_snapshots()
+        out = destroy_snapshot(self.job.filesystem, snapshots[-1])
+        self.assertEqual(0, out.returncode, msg=out.stderr)
 
         with open(self.test_file, 'w') as f:
             f.write('new data')

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -147,8 +147,8 @@ class JobTestsBase:
             f.write('append')
         self.job.start()
 
-        snapshots = self.job._snapshot_db.get_snapshots()
-        out = destroy_snapshot(self.job.filesystem, snapshots[-1])
+        snapshot_names = self.job._snapshot_db.get_snapshot_names()
+        out = destroy_snapshot(self.job.filesystem, snapshot_names[-1])
         self.assertEqual(0, out.returncode, msg=out.stderr)
 
         with open(self.test_file, 'w') as f:

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -155,7 +155,7 @@ class JobTestsBase:
             out = load_key(self.filesystem_2, 'file:///test_key')
             self.assertEqual(0, out.returncode, msg=out.stderr)
 
-            out = mount_filesystem(self.job.filesystem)
+            out = mount_filesystem(self.filesystem_2)
             self.assertEqual(0, out.returncode, msg=out.stderr)
 
         # Then

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -3,7 +3,7 @@ import subprocess
 import warnings
 
 from zfs_uploader.config import Config
-from zfs_uploader.zfs import (create_filesystem, destroy_filesystem,
+from zfs_uploader.zfs import (create_filesystem, destroy_filesystem, load_key,
                               SUBPROCESS_KWARGS)
 
 
@@ -79,6 +79,9 @@ class JobTestsBase:
 
         # When
         self.job.restore()
+        if self.encrypted_test:
+            out = load_key(self.job.filesystem)
+            self.assertEqual(0, out.returncode, msg=out.stderr)
 
         # Then
         with open(self.test_file, 'r') as f:
@@ -99,6 +102,9 @@ class JobTestsBase:
 
         # When
         self.job.restore()
+        if self.encrypted_test:
+            out = load_key(self.job.filesystem)
+            self.assertEqual(0, out.returncode, msg=out.stderr)
 
         # Then
         with open(self.test_file, 'r') as f:
@@ -120,6 +126,9 @@ class JobTestsBase:
         # When
         backups = self.job._backup_db.get_backup_times('inc')
         self.job.restore(backups[0])
+        if self.encrypted_test:
+            out = load_key(self.job.filesystem)
+            self.assertEqual(0, out.returncode, msg=out.stderr)
 
         # Then
         with open(self.test_file, 'r') as f:
@@ -133,6 +142,9 @@ class JobTestsBase:
 
         # When
         self.job.restore(filesystem=self.filesystem_2)
+        if self.encrypted_test:
+            out = load_key(self.filesystem_2)
+            self.assertEqual(0, out.returncode, msg=out.stderr)
 
         # Then
         test_file = f'/{self.filesystem_2}/test_file'
@@ -265,6 +277,7 @@ class JobTestsBase:
 
 class JobTestsUnencrypted(JobTestsBase, TestCase):
     def setUp(self):
+        self.encrypted_test = False
         warnings.filterwarnings("ignore", category=ResourceWarning,
                                 message="unclosed.*<ssl.SSLSocket.*>")
 
@@ -294,6 +307,7 @@ class JobTestsUnencrypted(JobTestsBase, TestCase):
 
 class JobTestsEncrypted(JobTestsBase, TestCase):
     def setUp(self):
+        self.encrypted_test = True
         warnings.filterwarnings("ignore", category=ResourceWarning,
                                 message="unclosed.*<ssl.SSLSocket.*>")
 

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -101,12 +101,6 @@ class JobTestsBase:
 
         # When
         self.job.restore()
-        if self.encrypted_test:
-            out = load_key(self.job.filesystem, 'file:///test_key')
-            self.assertEqual(0, out.returncode, msg=out.stderr)
-
-            out = mount_filesystem(self.job.filesystem)
-            self.assertEqual(0, out.returncode, msg=out.stderr)
 
         # Then
         with open(self.test_file, 'r') as f:
@@ -153,12 +147,6 @@ class JobTestsBase:
 
         # When
         self.job.restore()
-        if self.encrypted_test:
-            out = load_key(self.job.filesystem, 'file:///test_key')
-            self.assertEqual(0, out.returncode, msg=out.stderr)
-
-            out = mount_filesystem(self.job.filesystem)
-            self.assertEqual(0, out.returncode, msg=out.stderr)
 
         # Then
         with open(self.test_file, 'r') as f:

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -205,15 +205,13 @@ class JobTestsBase:
             f.write('append')
         self.job.start()
 
+        snapshot_names = self.job._snapshot_db.get_snapshot_names()
+        out = destroy_snapshot(self.job.filesystem, snapshot_names[0])
+        self.assertEqual(0, out.returncode, msg=out.stderr)
+
         # When
         backups = self.job._backup_db.get_backup_times('full')
         self.job.restore(backups[0])
-        if self.encrypted_test:
-            out = load_key(self.job.filesystem, 'file:///test_key')
-            self.assertEqual(0, out.returncode, msg=out.stderr)
-
-            out = mount_filesystem(self.job.filesystem)
-            self.assertEqual(0, out.returncode, msg=out.stderr)
 
         # Then
         with open(self.test_file, 'r') as f:

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -306,8 +306,9 @@ class JobTestsEncrypted(JobTestsBase, TestCase):
         with open('/test_key', 'w') as f:
             f.write('test_key')
         out = subprocess.run(
-            ['zfs', 'create', '-o', 'encryption=on',
-             '-o', 'keylocation=file:///test_key', self.job.filesystem],
+            ['zfs', 'create', '-o', 'encryption=on', '-o',
+             'keyformat=passphrase', '-o', 'keylocation=file:///test_key',
+             self.job.filesystem],
             **SUBPROCESS_KWARGS
         )
         self.assertEqual(0, out.returncode, msg=out.stderr)

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -80,7 +80,7 @@ class JobTestsBase:
         # When
         self.job.restore()
         if self.encrypted_test:
-            out = load_key(self.job.filesystem)
+            out = load_key(self.job.filesystem, 'file:///test_key')
             self.assertEqual(0, out.returncode, msg=out.stderr)
 
         # Then
@@ -103,7 +103,7 @@ class JobTestsBase:
         # When
         self.job.restore()
         if self.encrypted_test:
-            out = load_key(self.job.filesystem)
+            out = load_key(self.job.filesystem, 'file:///test_key')
             self.assertEqual(0, out.returncode, msg=out.stderr)
 
         # Then
@@ -127,7 +127,7 @@ class JobTestsBase:
         backups = self.job._backup_db.get_backup_times('inc')
         self.job.restore(backups[0])
         if self.encrypted_test:
-            out = load_key(self.job.filesystem)
+            out = load_key(self.job.filesystem, 'file:///test_key')
             self.assertEqual(0, out.returncode, msg=out.stderr)
 
         # Then
@@ -143,7 +143,7 @@ class JobTestsBase:
         # When
         self.job.restore(filesystem=self.filesystem_2)
         if self.encrypted_test:
-            out = load_key(self.filesystem_2)
+            out = load_key(self.filesystem_2, 'file:///test_key')
             self.assertEqual(0, out.returncode, msg=out.stderr)
 
         # Then

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -97,8 +97,8 @@ class JobTestsBase:
         # Given
         self.job.start()
 
-        snapshots = self.job._snapshot_db.get_snapshots()
-        out = destroy_snapshot(self.job.filesystem, snapshots[-1])
+        snapshot_names = self.job._snapshot_db.get_snapshot_names()
+        out = destroy_snapshot(self.job.filesystem, snapshot_names[-1])
         self.assertEqual(0, out.returncode, msg=out.stderr)
 
         with open(self.test_file, 'w') as f:

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -106,6 +106,12 @@ class JobTestsBase:
 
         # When
         self.job.restore()
+        if self.encrypted_test:
+            out = load_key(self.job.filesystem, 'file:///test_key')
+            self.assertEqual(0, out.returncode, msg=out.stderr)
+
+            out = mount_filesystem(self.job.filesystem)
+            self.assertEqual(0, out.returncode, msg=out.stderr)
 
         # Then
         with open(self.test_file, 'r') as f:

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -212,6 +212,12 @@ class JobTestsBase:
         # When
         backups = self.job._backup_db.get_backup_times('full')
         self.job.restore(backups[0])
+        if self.encrypted_test:
+            out = load_key(self.job.filesystem, 'file:///test_key')
+            self.assertEqual(0, out.returncode, msg=out.stderr)
+
+            out = mount_filesystem(self.job.filesystem)
+            self.assertEqual(0, out.returncode, msg=out.stderr)
 
         # Then
         with open(self.test_file, 'r') as f:

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -91,6 +91,28 @@ class JobTestsBase:
             out = f.read()
         self.assertEqual(self.test_data, out)
 
+    def test_restore_from_full_backup_with_new_data(self):
+        """ Test restore from full backup with new data. """
+        # Given
+        self.job.start()
+
+        with open(self.test_file, 'w') as f:
+            f.write('new data')
+
+        # When
+        self.job.restore()
+        if self.encrypted_test:
+            out = load_key(self.job.filesystem, 'file:///test_key')
+            self.assertEqual(0, out.returncode, msg=out.stderr)
+
+            out = mount_filesystem(self.job.filesystem)
+            self.assertEqual(0, out.returncode, msg=out.stderr)
+
+        # Then
+        with open(self.test_file, 'r') as f:
+            out = f.read()
+        self.assertEqual(self.test_data, out)
+
     def test_restore_from_incremental_backup(self):
         """ Test restore from incremental backup. """
         # Given
@@ -102,6 +124,32 @@ class JobTestsBase:
 
         out = destroy_filesystem(self.job.filesystem)
         self.assertEqual(0, out.returncode, msg=out.stderr)
+
+        # When
+        self.job.restore()
+        if self.encrypted_test:
+            out = load_key(self.job.filesystem, 'file:///test_key')
+            self.assertEqual(0, out.returncode, msg=out.stderr)
+
+            out = mount_filesystem(self.job.filesystem)
+            self.assertEqual(0, out.returncode, msg=out.stderr)
+
+        # Then
+        with open(self.test_file, 'r') as f:
+            out = f.read()
+        self.assertEqual(self.test_data + 'append', out)
+
+    def test_restore_from_incremental_backup_with_new_data(self):
+        """ Test restore from incremental backup with new data. """
+        # Given
+        self.job.start()
+
+        with open(self.test_file, 'a') as f:
+            f.write('append')
+        self.job.start()
+
+        with open(self.test_file, 'w') as f:
+            f.write('new data')
 
         # When
         self.job.restore()

--- a/zfs_uploader/job.py
+++ b/zfs_uploader/job.py
@@ -226,7 +226,9 @@ class ZFSjob:
         Defaults to most recent backup if backup_time is not specified.
 
         WARNING: If restoring to a file system that already exists, snapshots
-        and data that were written after the backup will be destroyed.
+        and data that were written after the backup will be destroyed. The
+        file system will also be destroyed if there are no snapshots at any
+        point during the restore process.
 
         Parameters
         ----------

--- a/zfs_uploader/job.py
+++ b/zfs_uploader/job.py
@@ -7,7 +7,7 @@ from boto3.s3.transfer import TransferConfig
 
 from zfs_uploader.backup_db import BackupDB
 from zfs_uploader.snapshot_db import SnapshotDB
-from zfs_uploader.zfs import (get_snapshot_send_size,
+from zfs_uploader.zfs import (destroy_filesystem, get_snapshot_send_size,
                               get_snapshot_send_size_inc,
                               open_snapshot_stream,
                               open_snapshot_stream_inc, rollback_filesystem,
@@ -250,6 +250,12 @@ class ZFSjob:
         backup_time = backup.backup_time
         backup_type = backup.backup_type
         s3_key = backup.s3_key
+
+        if not snapshots:
+            # Since we can't use the `-F` with `zfs receive` for encrypted
+            # file systems we have to remove file systems before restoring
+            # ourselves.
+            destroy_filesystem(backup.filesystem)
 
         if backup_type == 'full':
             if backup_time in snapshots and filesystem is None:

--- a/zfs_uploader/job.py
+++ b/zfs_uploader/job.py
@@ -271,6 +271,9 @@ class ZFSjob:
             self._snapshot_db.refresh()
             snapshots = self._snapshot_db.get_snapshot_names()
 
+            if not snapshots:
+                destroy_filesystem(backup.filesystem)
+
         if backup_type == 'full':
             if backup_time in snapshots and filesystem is None:
                 self._logger.info(f'filesystem={self.filesystem} '

--- a/zfs_uploader/job.py
+++ b/zfs_uploader/job.py
@@ -257,6 +257,11 @@ class ZFSjob:
             # Since we can't use the `-F` with `zfs receive` for encrypted
             # file systems we have to remove file systems before restoring
             # ourselves.
+            self._logger.info(f'filesystem={self.filesystem} '
+                              f'snapshot_name={backup_time} '
+                              f's3_key={s3_key} '
+                              'msg="Destroying filesystem since there are no '
+                              'snapshots."')
             destroy_filesystem(backup.filesystem)
 
         elif filesystem is None:
@@ -266,12 +271,22 @@ class ZFSjob:
                 snapshot_datetime = datetime.strptime(snapshot,
                                                       DATETIME_FORMAT)
                 if snapshot_datetime > backup_datetime:
+                    self._logger.info(f'filesystem={self.filesystem} '
+                                      f'snapshot_name={backup_time} '
+                                      f's3_key={s3_key} '
+                                      f'msg="Destroying {snapshot} since it '
+                                      'occurred after the backup."')
                     destroy_snapshot(backup.filesystem, snapshot)
 
             self._snapshot_db.refresh()
             snapshots = self._snapshot_db.get_snapshot_names()
 
             if not snapshots:
+                self._logger.info(f'filesystem={self.filesystem} '
+                                  f'snapshot_name={backup_time} '
+                                  f's3_key={s3_key} '
+                                  'msg="Destroying filesystem since there are '
+                                  'no snapshots."')
                 destroy_filesystem(backup.filesystem)
 
         if backup_type == 'full':

--- a/zfs_uploader/job.py
+++ b/zfs_uploader/job.py
@@ -263,10 +263,10 @@ class ZFSjob:
             # Destroy any snapshots that occurred after the backup
             backup_datetime = datetime.strptime(backup_time, DATETIME_FORMAT)
             for snapshot in snapshots:
-                snapshot_datetime = datetime.strptime(snapshot.name,
+                snapshot_datetime = datetime.strptime(snapshot,
                                                       DATETIME_FORMAT)
                 if snapshot_datetime > backup_datetime:
-                    destroy_snapshot(backup.filesystem, snapshot.name)
+                    destroy_snapshot(backup.filesystem, snapshot)
 
             self._snapshot_db.refresh()
             snapshots = self._snapshot_db.get_snapshot_names()

--- a/zfs_uploader/job.py
+++ b/zfs_uploader/job.py
@@ -258,8 +258,8 @@ class ZFSjob:
                                   f's3_key={s3_key} '
                                   'msg="Snapshot already exists."')
             else:
-                if snapshots:
-                    out = rollback_filesystem(filesystem, snapshots[-1])
+                if snapshots and filesystem is None:
+                    out = rollback_filesystem(backup.filesystem, snapshots[-1])
                     if out.returncode:
                         raise ZFSError(out.stderr)
 
@@ -275,8 +275,8 @@ class ZFSjob:
                                   f's3_key={backup_full.s3_key} '
                                   'msg="Snapshot already exists."')
             else:
-                if snapshots:
-                    out = rollback_filesystem(filesystem, snapshots[-1])
+                if snapshots and filesystem is None:
+                    out = rollback_filesystem(backup.filesystem, snapshots[-1])
                     if out.returncode:
                         raise ZFSError(out.stderr)
                     self._snapshot_db.refresh()
@@ -290,9 +290,10 @@ class ZFSjob:
                                   f's3_key={s3_key} '
                                   'msg="Snapshot already exists."')
             else:
-                out = rollback_filesystem(filesystem, snapshots[-1])
-                if out.returncode:
-                    raise ZFSError(out.stderr)
+                if snapshots and filesystem is None:
+                    out = rollback_filesystem(backup.filesystem, snapshots[-1])
+                    if out.returncode:
+                        raise ZFSError(out.stderr)
 
                 self._restore_snapshot(backup, filesystem)
 

--- a/zfs_uploader/job.py
+++ b/zfs_uploader/job.py
@@ -258,9 +258,10 @@ class ZFSjob:
                                   f's3_key={s3_key} '
                                   'msg="Snapshot already exists."')
             else:
-                out = rollback_filesystem(filesystem, snapshots[-1])
-                if out.returncode:
-                    raise ZFSError(out.stderr)
+                if snapshots:
+                    out = rollback_filesystem(filesystem, snapshots[-1])
+                    if out.returncode:
+                        raise ZFSError(out.stderr)
 
                 self._restore_snapshot(backup, filesystem)
 
@@ -274,11 +275,12 @@ class ZFSjob:
                                   f's3_key={backup_full.s3_key} '
                                   'msg="Snapshot already exists."')
             else:
-                out = rollback_filesystem(filesystem, snapshots[-1])
-                if out.returncode:
-                    raise ZFSError(out.stderr)
-                self._snapshot_db.refresh()
-                snapshots = self._snapshot_db.get_snapshot_names()
+                if snapshots:
+                    out = rollback_filesystem(filesystem, snapshots[-1])
+                    if out.returncode:
+                        raise ZFSError(out.stderr)
+                    self._snapshot_db.refresh()
+                    snapshots = self._snapshot_db.get_snapshot_names()
 
                 self._restore_snapshot(backup_full, filesystem)
 

--- a/zfs_uploader/job.py
+++ b/zfs_uploader/job.py
@@ -7,7 +7,7 @@ from boto3.s3.transfer import TransferConfig
 
 from zfs_uploader.backup_db import BackupDB
 from zfs_uploader.snapshot_db import SnapshotDB
-from zfs_uploader.zfs import (create_filesystem, get_snapshot_send_size,
+from zfs_uploader.zfs import (get_snapshot_send_size,
                               get_snapshot_send_size_inc,
                               open_snapshot_stream,
                               open_snapshot_stream_inc, ZFSError)
@@ -249,11 +249,6 @@ class ZFSjob:
         backup_time = backup.backup_time
         backup_type = backup.backup_type
         s3_key = backup.s3_key
-
-        if filesystem:
-            out = create_filesystem(filesystem)
-            if out.returncode:
-                raise ZFSError(out.stderr)
 
         if backup_type == 'full':
             if backup_time in snapshots and filesystem is None:

--- a/zfs_uploader/zfs.py
+++ b/zfs_uploader/zfs.py
@@ -74,7 +74,7 @@ def open_snapshot_stream(filesystem, snapshot_name, mode):
         return subprocess.Popen(cmd, stdout=subprocess.PIPE,
                                 stderr=subprocess.PIPE)
     elif mode == 'w':
-        cmd = ['zfs', 'receive', '-F', f'{filesystem}@{snapshot_name}']
+        cmd = ['zfs', 'receive', f'{filesystem}@{snapshot_name}']
         return subprocess.Popen(cmd, stdin=subprocess.PIPE,
                                 stdout=subprocess.PIPE,
                                 stderr=subprocess.PIPE)

--- a/zfs_uploader/zfs.py
+++ b/zfs_uploader/zfs.py
@@ -90,7 +90,7 @@ def open_snapshot_stream_inc(filesystem, snapshot_name_1, snapshot_name_2):
                             stderr=subprocess.PIPE)
 
 
-def load_key(filesystem):
+def load_key(filesystem, keylocation):
     """ Load encryption key. """
-    cmd = ['zfs', 'load-key', filesystem]
+    cmd = ['zfs', 'load-key', '-L', keylocation, filesystem]
     return subprocess.run(cmd, **SUBPROCESS_KWARGS)

--- a/zfs_uploader/zfs.py
+++ b/zfs_uploader/zfs.py
@@ -58,6 +58,12 @@ def mount_filesystem(filesystem):
     return subprocess.run(cmd, **SUBPROCESS_KWARGS)
 
 
+def rollback_filesystem(filesystem, snapshot_name):
+    """ Rollback filesystem. """
+    cmd = ['zfs', 'rollback', '-r', f'{filesystem}@{snapshot_name}']
+    return subprocess.run(cmd, **SUBPROCESS_KWARGS)
+
+
 def get_snapshot_send_size(filesystem, snapshot_name):
     cmd = ['zfs', 'send', '--raw', '--parsable', '--dryrun',
            f'{filesystem}@{snapshot_name}']

--- a/zfs_uploader/zfs.py
+++ b/zfs_uploader/zfs.py
@@ -88,3 +88,9 @@ def open_snapshot_stream_inc(filesystem, snapshot_name_1, snapshot_name_2):
            f'{filesystem}@{snapshot_name_2}']
     return subprocess.Popen(cmd, stdout=subprocess.PIPE,
                             stderr=subprocess.PIPE)
+
+
+def load_key(filesystem):
+    """ Load encryption key. """
+    cmd = ['zfs', 'load-key', filesystem]
+    return subprocess.run(cmd, **SUBPROCESS_KWARGS)

--- a/zfs_uploader/zfs.py
+++ b/zfs_uploader/zfs.py
@@ -52,6 +52,12 @@ def destroy_filesystem(filesystem):
     return subprocess.run(cmd, **SUBPROCESS_KWARGS)
 
 
+def mount_filesystem(filesystem):
+    """ Mount filesystem. """
+    cmd = ['zfs', 'mount', filesystem]
+    return subprocess.run(cmd, **SUBPROCESS_KWARGS)
+
+
 def get_snapshot_send_size(filesystem, snapshot_name):
     cmd = ['zfs', 'send', '--raw', '--parsable', '--dryrun',
            f'{filesystem}@{snapshot_name}']


### PR DESCRIPTION
This PR makes the following major changes:
- Remove the `-F` option from `zfs receive` since it doesn't work with encrypted filesystems
- Add encrypted filesystem tests
- Remove filesystems, snapshots and data written after the most recent snapshot during restore