### PR TITLE
Add s3_prefix config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ jobs can be set in one file.
    S3 secret key.
 #### filesystem : str
    ZFS filesystem.
-#### s3_prefix : str, optional
+#### prefix : str, optional
    Prefix to be prepended to the s3 key.
 #### region : str, default: us-east-1
    S3 region.

--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ jobs can be set in one file.
    S3 secret key.
 #### filesystem : str
    ZFS filesystem.
+#### s3_prefix : str, optional
+   Prefix to be prepended to the s3 key.
 #### region : str, default: us-east-1
    S3 region.
 #### endpoint : str, optional

--- a/tests/test_backup_db.py
+++ b/tests/test_backup_db.py
@@ -3,6 +3,7 @@ import warnings
 
 from zfs_uploader.config import Config
 from zfs_uploader.backup_db import BackupDB
+from zfs_uploader.utils import derive_s3_key
 
 
 class BackupDBTests(unittest.TestCase):
@@ -14,6 +15,7 @@ class BackupDBTests(unittest.TestCase):
         self.job = next(iter(config.jobs.values()))
         self.bucket = self.job.bucket
         self.filesystem = self.job.filesystem
+        self.s3_prefix = self.job.s3_prefix
 
     def tearDown(self):
         for item in self.bucket.objects.all():
@@ -22,16 +24,18 @@ class BackupDBTests(unittest.TestCase):
     def test_create_backup_db(self):
         """ Test if backup.db file is properly uploaded/downloaded. """
         # Given
-        backup_db = BackupDB(self.bucket, self.filesystem)
+        backup_db = BackupDB(self.bucket, self.filesystem, self.s3_prefix)
         backup_time = '20210425_201838'
         backup_type = 'full'
-        s3_key = f'{self.filesystem}/{backup_time}.{backup_type}'
+
+        object_name = f'{backup_time}.{backup_type}'
+        s3_key = derive_s3_key(object_name, self.filesystem, self.s3_prefix)
 
         # When
         backup_db.create_backup(backup_time, backup_type, s3_key)
 
         # Then
-        backup_db_new = BackupDB(self.bucket, self.filesystem)
+        backup_db_new = BackupDB(self.bucket, self.filesystem, self.s3_prefix)
 
         self.assertEqual(
             backup_db.get_backup(backup_time),
@@ -41,10 +45,12 @@ class BackupDBTests(unittest.TestCase):
     def test_delete_backup(self):
         """ Test delete backup from backup_db. """
         # Given
-        backup_db = BackupDB(self.bucket, self.filesystem)
+        backup_db = BackupDB(self.bucket, self.filesystem, self.s3_prefix)
         backup_time = '20210425_201838'
         backup_type = 'full'
-        s3_key = f'{self.filesystem}/{backup_time}.{backup_type}'
+
+        object_name = f'{backup_time}.{backup_type}'
+        s3_key = derive_s3_key(object_name, self.filesystem, self.s3_prefix)
 
         backup_db.create_backup(backup_time, backup_type, s3_key)
         backup_db.get_backup(backup_time)
@@ -58,10 +64,12 @@ class BackupDBTests(unittest.TestCase):
     def test_existing_backup(self):
         """ Test create existing backup. """
         # Given
-        backup_db = BackupDB(self.bucket, self.filesystem)
+        backup_db = BackupDB(self.bucket, self.filesystem, self.s3_prefix)
         backup_time = '20210425_201838'
         backup_type = 'full'
-        s3_key = f'{self.filesystem}/{backup_time}.{backup_type}'
+
+        object_name = f'{backup_time}.{backup_type}'
+        s3_key = derive_s3_key(object_name, self.filesystem, self.s3_prefix)
 
         # When
         backup_db.create_backup(backup_time, backup_type, s3_key)
@@ -73,10 +81,12 @@ class BackupDBTests(unittest.TestCase):
     def test_bad_backup_time(self):
         """ Test create backup with bad backup_time. """
         # Given
-        backup_db = BackupDB(self.bucket, self.filesystem)
+        backup_db = BackupDB(self.bucket, self.filesystem, self.s3_prefix)
         backup_time = '20210425-201838'
         backup_type = 'full'
-        s3_key = f'{self.filesystem}/{backup_time}.{backup_type}'
+
+        object_name = f'{backup_time}.{backup_type}'
+        s3_key = derive_s3_key(object_name, self.filesystem, self.s3_prefix)
 
         # Then
         self.assertRaises(ValueError, backup_db.create_backup, backup_time,
@@ -88,7 +98,9 @@ class BackupDBTests(unittest.TestCase):
         backup_db = BackupDB(self.bucket, self.filesystem)
         backup_time = '20210425_201838'
         backup_type = 'badtype'
-        s3_key = f'{self.filesystem}/{backup_time}.{backup_type}'
+
+        object_name = f'{backup_time}.{backup_type}'
+        s3_key = derive_s3_key(object_name, self.filesystem, self.s3_prefix)
 
         # Then
         self.assertRaises(ValueError, backup_db.create_backup, backup_time,
@@ -98,10 +110,13 @@ class BackupDBTests(unittest.TestCase):
         """ Test creating a backup with a bad dependency. """
 
         # Given
-        backup_db = BackupDB(self.bucket, self.filesystem)
+        backup_db = BackupDB(self.bucket, self.filesystem, self.s3_prefix)
         backup_time = '20210425_201838'
         backup_type = 'full'
-        s3_key = f'{self.filesystem}/{backup_time}.{backup_type}'
+
+        s3_key = derive_s3_key(f'{backup_time}.{backup_type}', self.filesystem,
+                               self.s3_prefix)
+
         dependency = '20200425-201838'
 
         # Then

--- a/tests/test_backup_db.py
+++ b/tests/test_backup_db.py
@@ -15,7 +15,7 @@ class BackupDBTests(unittest.TestCase):
         self.job = next(iter(config.jobs.values()))
         self.bucket = self.job.bucket
         self.filesystem = self.job.filesystem
-        self.s3_prefix = self.job.s3_prefix
+        self.prefix = self.job.prefix
 
     def tearDown(self):
         for item in self.bucket.objects.all():
@@ -24,18 +24,18 @@ class BackupDBTests(unittest.TestCase):
     def test_create_backup_db(self):
         """ Test if backup.db file is properly uploaded/downloaded. """
         # Given
-        backup_db = BackupDB(self.bucket, self.filesystem, self.s3_prefix)
+        backup_db = BackupDB(self.bucket, self.filesystem, self.prefix)
         backup_time = '20210425_201838'
         backup_type = 'full'
 
         object_name = f'{backup_time}.{backup_type}'
-        s3_key = derive_s3_key(object_name, self.filesystem, self.s3_prefix)
+        s3_key = derive_s3_key(object_name, self.filesystem, self.prefix)
 
         # When
         backup_db.create_backup(backup_time, backup_type, s3_key)
 
         # Then
-        backup_db_new = BackupDB(self.bucket, self.filesystem, self.s3_prefix)
+        backup_db_new = BackupDB(self.bucket, self.filesystem, self.prefix)
 
         self.assertEqual(
             backup_db.get_backup(backup_time),
@@ -45,12 +45,12 @@ class BackupDBTests(unittest.TestCase):
     def test_delete_backup(self):
         """ Test delete backup from backup_db. """
         # Given
-        backup_db = BackupDB(self.bucket, self.filesystem, self.s3_prefix)
+        backup_db = BackupDB(self.bucket, self.filesystem, self.prefix)
         backup_time = '20210425_201838'
         backup_type = 'full'
 
         object_name = f'{backup_time}.{backup_type}'
-        s3_key = derive_s3_key(object_name, self.filesystem, self.s3_prefix)
+        s3_key = derive_s3_key(object_name, self.filesystem, self.prefix)
 
         backup_db.create_backup(backup_time, backup_type, s3_key)
         backup_db.get_backup(backup_time)
@@ -64,12 +64,12 @@ class BackupDBTests(unittest.TestCase):
     def test_existing_backup(self):
         """ Test create existing backup. """
         # Given
-        backup_db = BackupDB(self.bucket, self.filesystem, self.s3_prefix)
+        backup_db = BackupDB(self.bucket, self.filesystem, self.prefix)
         backup_time = '20210425_201838'
         backup_type = 'full'
 
         object_name = f'{backup_time}.{backup_type}'
-        s3_key = derive_s3_key(object_name, self.filesystem, self.s3_prefix)
+        s3_key = derive_s3_key(object_name, self.filesystem, self.prefix)
 
         # When
         backup_db.create_backup(backup_time, backup_type, s3_key)
@@ -81,12 +81,12 @@ class BackupDBTests(unittest.TestCase):
     def test_bad_backup_time(self):
         """ Test create backup with bad backup_time. """
         # Given
-        backup_db = BackupDB(self.bucket, self.filesystem, self.s3_prefix)
+        backup_db = BackupDB(self.bucket, self.filesystem, self.prefix)
         backup_time = '20210425-201838'
         backup_type = 'full'
 
         object_name = f'{backup_time}.{backup_type}'
-        s3_key = derive_s3_key(object_name, self.filesystem, self.s3_prefix)
+        s3_key = derive_s3_key(object_name, self.filesystem, self.prefix)
 
         # Then
         self.assertRaises(ValueError, backup_db.create_backup, backup_time,
@@ -100,7 +100,7 @@ class BackupDBTests(unittest.TestCase):
         backup_type = 'badtype'
 
         object_name = f'{backup_time}.{backup_type}'
-        s3_key = derive_s3_key(object_name, self.filesystem, self.s3_prefix)
+        s3_key = derive_s3_key(object_name, self.filesystem, self.prefix)
 
         # Then
         self.assertRaises(ValueError, backup_db.create_backup, backup_time,
@@ -110,12 +110,12 @@ class BackupDBTests(unittest.TestCase):
         """ Test creating a backup with a bad dependency. """
 
         # Given
-        backup_db = BackupDB(self.bucket, self.filesystem, self.s3_prefix)
+        backup_db = BackupDB(self.bucket, self.filesystem, self.prefix)
         backup_time = '20210425_201838'
         backup_type = 'full'
 
-        s3_key = derive_s3_key(f'{backup_time}.{backup_type}', self.filesystem,
-                               self.s3_prefix)
+        object_name = f'{backup_time}.{backup_type}'
+        s3_key = derive_s3_key(object_name, self.filesystem, self.prefix)
 
         dependency = '20200425-201838'
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,33 @@
+import unittest
+
+from zfs_uploader.config import Config
+from zfs_uploader.utils import derive_s3_key
+
+
+class UtilTests(unittest.TestCase):
+    def setUp(self):
+        # Given
+        config = Config('config.cfg')
+        job = next(iter(config.jobs.values()))
+        self.filesystem = job.filesystem
+
+    def test_derive_s3_key_no_prefix(self):
+        """ Test create s3 key without prefix. """
+        # When
+        object_name = '20210425_201838.full'
+        s3_key = derive_s3_key(object_name, self.filesystem)
+
+        # Then
+        self.assertEqual(s3_key, f'{self.filesystem}/{object_name}')
+
+    def test_derive_s3_key_with_prefix(self):
+        """ Test create s3 key with prefix. """
+        # Given
+        prefix = 'prefix'
+
+        # When
+        object_name = '20210425_201838.full'
+        s3_key = derive_s3_key(object_name, self.filesystem, prefix)
+
+        # Then
+        self.assertEqual(s3_key, f'{prefix}/{self.filesystem}/{object_name}')

--- a/zfs_uploader/backup_db.py
+++ b/zfs_uploader/backup_db.py
@@ -5,6 +5,7 @@ import json
 from botocore.exceptions import ClientError # noqa
 
 from zfs_uploader import BACKUP_DB_FILE, DATETIME_FORMAT
+from zfs_uploader.utils import derive_s3_key
 
 
 class BackupDB:
@@ -15,7 +16,7 @@ class BackupDB:
         """ ZFS filesystem. """
         return self._filesystem
 
-    def __init__(self, bucket, filesystem):
+    def __init__(self, bucket, filesystem, s3_prefix=None):
         """ Create BackupDB object.
 
         BackupDB is used for storing Backup objects. It does not upload
@@ -27,12 +28,15 @@ class BackupDB:
             S3 Bucket.
         filesystem : str
             ZFS filesystem.
+        s3_prefix: str, optional
+            The s3 prefix to prepend to the backup.db file.
 
         """
         self._filesystem = filesystem
         self._backups = {}
-        self._s3_object = bucket.Object(
-            f'{self._filesystem}/{BACKUP_DB_FILE}')
+
+        s3_key = derive_s3_key(BACKUP_DB_FILE, self.filesystem, s3_prefix)
+        self._s3_object = bucket.Object(s3_key)
 
         # initialize from backup.db file if it exists
         self.download()

--- a/zfs_uploader/config.py
+++ b/zfs_uploader/config.py
@@ -65,8 +65,8 @@ class Config:
                         access_key,
                         secret_key,
                         filesystem,
-                        s3_prefix=(v.get('s3_prefix') or
-                                   default.get('s3_prefix')),
+                        prefix=(v.get('prefix') or
+                                   default.get('prefix')),
                         region=v.get('region') or default.get('region'),
                         endpoint=v.get('endpoint') or default.get('endpoint'),
                         cron=cron_dict,

--- a/zfs_uploader/config.py
+++ b/zfs_uploader/config.py
@@ -65,8 +65,7 @@ class Config:
                         access_key,
                         secret_key,
                         filesystem,
-                        prefix=(v.get('prefix') or
-                                   default.get('prefix')),
+                        prefix=v.get('prefix') or default.get('prefix'),
                         region=v.get('region') or default.get('region'),
                         endpoint=v.get('endpoint') or default.get('endpoint'),
                         cron=cron_dict,

--- a/zfs_uploader/config.py
+++ b/zfs_uploader/config.py
@@ -65,6 +65,8 @@ class Config:
                         access_key,
                         secret_key,
                         filesystem,
+                        s3_prefix=(v.get('s3_prefix') or
+                                   default.get('s3_prefix')),
                         region=v.get('region') or default.get('region'),
                         endpoint=v.get('endpoint') or default.get('endpoint'),
                         cron=cron_dict,

--- a/zfs_uploader/job.py
+++ b/zfs_uploader/job.py
@@ -62,9 +62,9 @@ class ZFSjob:
         return self._filesystem
 
     @property
-    def s3_prefix(self):
+    def prefix(self):
         """ S3 key prefix. """
-        return self._s3_prefix
+        return self._prefix
 
     @property
     def s3(self):
@@ -112,7 +112,7 @@ class ZFSjob:
         return self._snapshot_db
 
     def __init__(self, bucket_name, access_key, secret_key, filesystem,
-                 s3_prefix=None, region=None, cron=None, max_snapshots=None,
+                 prefix=None, region=None, cron=None, max_snapshots=None,
                  max_backups=None, max_incremental_backups_per_full=None,
                  storage_class=None, endpoint=None, max_multipart_parts=None):
         """ Create ZFSjob object.
@@ -127,7 +127,7 @@ class ZFSjob:
             S3 secret key.
         filesystem : str
             ZFS filesystem.
-        s3_prefix : str, optional
+        prefix : str, optional
             The prefix added to the s3 key for backups.
         region : str, default: us-east-1
             S3 region.
@@ -152,7 +152,7 @@ class ZFSjob:
         self._access_key = access_key
         self._secret_key = secret_key
         self._filesystem = filesystem
-        self._s3_prefix = s3_prefix
+        self._prefix = prefix
         self._endpoint = endpoint
 
         self._s3 = boto3.resource(service_name='s3',
@@ -162,7 +162,7 @@ class ZFSjob:
                                   endpoint_url=endpoint)
         self._bucket = self._s3.Bucket(self._bucket_name)
         self._backup_db = BackupDB(self._bucket, self._filesystem,
-                                   self._s3_prefix)
+                                   self._prefix)
         self._snapshot_db = SnapshotDB(self._filesystem)
         self._cron = cron
         self._max_snapshots = max_snapshots
@@ -357,7 +357,7 @@ class ZFSjob:
                                                self._max_multipart_parts)
 
         s3_key = derive_s3_key(f'{backup_time}.full', filesystem,
-                               self.s3_prefix)
+                               self.prefix)
 
         self._logger.info(f'filesystem={filesystem} '
                           f'snapshot_name={backup_time} '
@@ -407,7 +407,7 @@ class ZFSjob:
                                                self._max_multipart_parts)
 
         s3_key = derive_s3_key(f'{backup_time}.inc', filesystem,
-                               self.s3_prefix)
+                               self.prefix)
 
         self._logger.info(f'filesystem={filesystem} '
                           f'snapshot_name={backup_time} '

--- a/zfs_uploader/job.py
+++ b/zfs_uploader/job.py
@@ -63,7 +63,7 @@ class ZFSjob:
 
     @property
     def prefix(self):
-        """ S3 key prefix. """
+        """ Prefix to be prepended to the s3 key. """
         return self._prefix
 
     @property

--- a/zfs_uploader/job.py
+++ b/zfs_uploader/job.py
@@ -8,6 +8,7 @@ from boto3.s3.transfer import TransferConfig
 
 from zfs_uploader.backup_db import BackupDB, DATETIME_FORMAT
 from zfs_uploader.snapshot_db import SnapshotDB
+from zfs_uploader.utils import derive_s3_key
 from zfs_uploader.zfs import (destroy_filesystem, destroy_snapshot,
                               get_snapshot_send_size,
                               get_snapshot_send_size_inc,
@@ -61,6 +62,11 @@ class ZFSjob:
         return self._filesystem
 
     @property
+    def s3_prefix(self):
+        """ S3 key prefix. """
+        return self._s3_prefix
+
+    @property
     def s3(self):
         """ S3 resource. """
         return self._s3
@@ -106,9 +112,9 @@ class ZFSjob:
         return self._snapshot_db
 
     def __init__(self, bucket_name, access_key, secret_key, filesystem,
-                 region=None, cron=None, max_snapshots=None, max_backups=None,
-                 max_incremental_backups_per_full=None, storage_class=None,
-                 endpoint=None, max_multipart_parts=None):
+                 s3_prefix=None, region=None, cron=None, max_snapshots=None,
+                 max_backups=None, max_incremental_backups_per_full=None,
+                 storage_class=None, endpoint=None, max_multipart_parts=None):
         """ Create ZFSjob object.
 
         Parameters
@@ -121,6 +127,8 @@ class ZFSjob:
             S3 secret key.
         filesystem : str
             ZFS filesystem.
+        s3_prefix : str, optional
+            The prefix added to the s3 key for backups.
         region : str, default: us-east-1
             S3 region.
         endpoint : str, optional
@@ -144,6 +152,7 @@ class ZFSjob:
         self._access_key = access_key
         self._secret_key = secret_key
         self._filesystem = filesystem
+        self._s3_prefix = s3_prefix
         self._endpoint = endpoint
 
         self._s3 = boto3.resource(service_name='s3',
@@ -152,7 +161,8 @@ class ZFSjob:
                                   aws_secret_access_key=self._secret_key,
                                   endpoint_url=endpoint)
         self._bucket = self._s3.Bucket(self._bucket_name)
-        self._backup_db = BackupDB(self._bucket, self._filesystem)
+        self._backup_db = BackupDB(self._bucket, self._filesystem,
+                                   self._s3_prefix)
         self._snapshot_db = SnapshotDB(self._filesystem)
         self._cron = cron
         self._max_snapshots = max_snapshots
@@ -346,7 +356,9 @@ class ZFSjob:
         transfer_config = _get_transfer_config(send_size,
                                                self._max_multipart_parts)
 
-        s3_key = f'{filesystem}/{backup_time}.full'
+        s3_key = derive_s3_key(f'{backup_time}.full', filesystem,
+                               self.s3_prefix)
+
         self._logger.info(f'filesystem={filesystem} '
                           f'snapshot_name={backup_time} '
                           f's3_key={s3_key} '
@@ -394,7 +406,9 @@ class ZFSjob:
         transfer_config = _get_transfer_config(send_size,
                                                self._max_multipart_parts)
 
-        s3_key = f'{filesystem}/{backup_time}.inc'
+        s3_key = derive_s3_key(f'{backup_time}.inc', filesystem,
+                               self.s3_prefix)
+
         self._logger.info(f'filesystem={filesystem} '
                           f'snapshot_name={backup_time} '
                           f's3_key={s3_key} '

--- a/zfs_uploader/utils.py
+++ b/zfs_uploader/utils.py
@@ -12,3 +12,27 @@ def get_date_time():
 
     """
     return datetime.now().strftime(DATETIME_FORMAT)
+
+
+def derive_s3_key(object_name, filesystem, s3_prefix=None):
+    """
+    Derive the s3 key for the object.
+
+    Parameters
+    ----------
+    object_name : str
+      The object name. Such as backup.db or the full/inc snapshot name.
+    filesystem : str
+      The ZFS filesystem.
+    s3_prefix : str, optional
+      The s3 prefix to prepend to the key.
+
+    Returns
+    -------
+    string
+
+    """
+    s3_key = f'{filesystem}/{object_name}'
+    if s3_prefix is not None:
+        s3_key = f'{s3_prefix}/{s3_key}'
+    return s3_key

--- a/zfs_uploader/utils.py
+++ b/zfs_uploader/utils.py
@@ -14,7 +14,7 @@ def get_date_time():
     return datetime.now().strftime(DATETIME_FORMAT)
 
 
-def derive_s3_key(object_name, filesystem, s3_prefix=None):
+def derive_s3_key(object_name, filesystem, prefix=None):
     """
     Derive the s3 key for the object.
 
@@ -24,7 +24,7 @@ def derive_s3_key(object_name, filesystem, s3_prefix=None):
       The object name. Such as backup.db or the full/inc snapshot name.
     filesystem : str
       The ZFS filesystem.
-    s3_prefix : str, optional
+    prefix : str, optional
       The s3 prefix to prepend to the key.
 
     Returns
@@ -33,6 +33,6 @@ def derive_s3_key(object_name, filesystem, s3_prefix=None):
 
     """
     s3_key = f'{filesystem}/{object_name}'
-    if s3_prefix is not None:
-        s3_key = f'{s3_prefix}/{s3_key}'
+    if prefix is not None:
+        s3_key = f'{prefix}/{s3_key}'
     return s3_key


### PR DESCRIPTION
Adds the ability to prefix s3 keys. This is useful if multiple hosts have similar named ZFS filesystems, but ultimately we want these backups to be going to the same bucket