### PR TITLE
Draft: Add ability to backup recursively

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.0](https://github.com/ddebeau/zfs_uploader/compare/0.9.0...0.10.0) 2023-09-12
+
+### Added
+
+- Add the ability to recursively backup nested filesystems
+[#72](https://github.com/ddebeau/zfs_uploader/pull/72)
+
+
 ## [0.9.0](https://github.com/ddebeau/zfs_uploader/compare/0.8.1...0.9.0) 2023-08-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ jobs can be set in one file.
    S3 storage class.
 #### max_multipart_parts : int, default: 10000
    Maximum number of parts to use in a multipart S3 upload.
+#### recursive : bool, default: false
+   Backup nested ZFS datasets and volumes along with the given one.
 
 ### Examples
 #### Multiple full backups
@@ -100,6 +102,7 @@ cron = 0 2 * * *
 max_snapshots = 7
 max_incremental_backups_per_full = 6
 max_backups = 7
+recursive = false
 ```
 
 Filesystem is backed up at 02:00 daily. Only the most recent 7 snapshots

--- a/sample_config.cfg
+++ b/sample_config.cfg
@@ -10,3 +10,4 @@ cron = 0 2 * * *
 max_snapshots = 7
 max_incremental_backups_per_full = 6
 max_backups = 7
+recursive = false

--- a/write_test_config.py
+++ b/write_test_config.py
@@ -13,7 +13,8 @@ config['DEFAULT'] = {
 config['test-pool/test-filesystem'] = {
     'cron': '* * * * *',
     'max_snapshots': 3,
-    'max_incremental_backups': 5
+    'max_incremental_backups': 5,
+    'recursive': False
 }
 
 with open('config.cfg', 'w') as f:

--- a/zfs_uploader/zfs.py
+++ b/zfs_uploader/zfs.py
@@ -27,6 +27,12 @@ def list_snapshots():
 
     return snapshots
 
+def list_children(filesystem):
+    """ List filesystem children for recursive backup. """
+    cmd = ['zfs', 'list', '-o', 'name', '-H', '-r', f'{filesystem}']
+    out = subprocess.run(cmd, **SUBPROCESS_KWARGS)
+
+    return out.stdout.splitlines()
 
 def create_snapshot(filesystem, snapshot_name):
     """ Create filesystem snapshot. """


### PR DESCRIPTION
Add a flag to enable recursive backup, effectively uploading nested chilren filesystems recursively (being ZFS datasets and volumes).

Follows the late feature request #65.

I’m opening this draft to collect early reviews and suggestions. I’m especially interested in reviews regarding the coding style and implementation logic :-)

## TODO

- [ ] Add automated testing around `list_children(filesystem)`
- [ ] Run manual testing over a real world use case

## Typical use cases

I require the feature as I use Docker’s ZFS storage driver leading me to 300+ ZFS datasets I’d like to snapshot, on top of the base hundred I have on my pool.

## Open questions

Those are questions this new feature raise, and feature ideas that might come up in future PRs. I’m wondering if those are really useful, if they get decent alternatives, and/or if they’re worth the extra complexity.

### 1. Should a removed filesystem (e.g. a removed Docker volume) lead to garbage collection on the remote backup storage?

It might be great to get a command such as `zfsup cleanup -f` removing old and locally removed filesystems as a cron schedule for instance. Might be useful in some very specific cases.

### 2. Should we add an `except` option to pick recursively all filesystems _but_ a few ones?

I’m thinking of a recursive backup of all datasets but a few ones, such as temporary files or big datasets (e.g. for datasets such as  `/tmp` and games someone don’t wish to backup, but would like to backup every other ones). Without the except feature, I believe that would prevent from using a higher-level recursive backups there.