### PR TITLE
Use incremental backups as base for new backups to save storage cost

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,9 +29,6 @@ jobs:
     
     - name: Create S3 bucket
       run: |
-        curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-        unzip awscliv2.zip
-        sudo ./aws/install
         aws --endpoint-url=http://s3:4566 s3 mb s3://testbucket
     
     - name: Run Flake8

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
     
     - name: Create S3 bucket
       run: |
-        aws --endpoint-url=http://s3:4566 s3 mb s3://testbucket
+        aws --endpoint-url=http://s3:4566 s3 mb s3://testbucket --debug
     
     - name: Run Flake8
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,8 +28,11 @@ jobs:
         python-version: 3.6
     
     - name: Create S3 bucket
+      env:
+        AWS_ACCESS_KEY_ID: testkey
+        AWS_SECRET_ACCESS_KEY: testsecret
       run: |
-        aws --endpoint-url=http://s3:4566 s3 mb s3://testbucket --debug
+        aws --endpoint-url=http://s3:4566 s3 mb s3://testbucket --region us-east-2
     
     - name: Run Flake8
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
         AWS_ACCESS_KEY_ID: testkey
         AWS_SECRET_ACCESS_KEY: testsecret
       run: |
-        aws --endpoint-url=http://s3:4566 s3 mb s3://testbucket --region us-east-2
+        aws --endpoint-url=http://localhost:4566 s3 mb s3://testbucket --region us-east-2
     
     - name: Run Flake8
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,14 @@ jobs:
   test:
     environment: test
     runs-on: ubuntu-20.04
+
+    services:
+      s3:
+        image: localstack/localstack
+        ports:
+           - 4566:4566
+
+
     steps:
     - uses: actions/checkout@v3
     - name: Install Python 3.6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,10 +7,9 @@ jobs:
   test:
     environment: test
     runs-on: ubuntu-20.04
-
     services:
       s3:
-        image: localstack/localstack
+        image: localstack/localstack:s3-latest
         ports:
            - 4566:4566
         env:
@@ -18,22 +17,18 @@ jobs:
           AWS_ACCESS_KEY_ID: testkey
           AWS_SECRET_ACCESS_KEY: testsecret
           DEFAULT_REGION: us-east-2
-
-
     steps:
     - uses: actions/checkout@v3
     - name: Install Python 3.6
       uses: actions/setup-python@v4
       with:
         python-version: 3.6
-    
     - name: Create S3 bucket
       env:
         AWS_ACCESS_KEY_ID: testkey
         AWS_SECRET_ACCESS_KEY: testsecret
       run: |
         aws --endpoint-url=http://localhost:4566 s3 mb s3://testbucket --region us-east-2
-    
     - name: Run Flake8
       run: |
         pip install --upgrade pip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,7 +57,7 @@ jobs:
         AWS_SECRET_ACCESS_KEY: testsecret
         AWS_DEFAULT_REGION: us-east-2
         S3_BUCKET: testbucket
-        ENDPOINT: http://s3:4566
+        ENDPOINT: http://localhost:4566
       run: |
         python write_test_config.py
         sudo python -m unittest -v

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,11 @@ jobs:
         image: localstack/localstack
         ports:
            - 4566:4566
+        env:
+          SERVICES: s3
+          AWS_ACCESS_KEY_ID: testkey
+          AWS_SECRET_ACCESS_KEY: testsecret
+          DEFAULT_REGION: us-east-2
 
 
     steps:
@@ -21,6 +26,14 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: 3.6
+    
+    - name: Create S3 bucket
+      run: |
+        curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+        unzip awscliv2.zip
+        sudo ./aws/install
+        aws --endpoint-url=http://s3:4566 s3 mb s3://testbucket
+    
     - name: Run Flake8
       run: |
         pip install --upgrade pip
@@ -40,10 +53,11 @@ jobs:
         /home/runner/work/zfs_uploader/zfs_uploader/disk-image
     - name: Run test suite
       env:
-        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        AWS_ACCESS_KEY_ID: testkey
+        AWS_SECRET_ACCESS_KEY: testsecret
         AWS_DEFAULT_REGION: us-east-2
-        S3_BUCKET: zfs-uploader20210609233519641800000001
+        S3_BUCKET: testbucket
+        ENDPOINT: http://s3:4566
       run: |
         python write_test_config.py
         sudo python -m unittest -v

--- a/README.md
+++ b/README.md
@@ -202,6 +202,36 @@ full backup (f)
 6.  f f f f f f
 7.  f f f f f f f
 
+## Max backups limit behaviour
+Once the max limit is reached, the program would remove the oldest chain. 
+If a single full exists, a new full would be created and all the past chain deleted.
+The end result would be a single full in this case.
+
+### Limit examples
+
+max_backups = 7
+
+max_incremental_backups_per_full = 3
+
+1. f
+2. fi
+3. fii
+4. fiii
+5. fiiif
+6. fiiifi
+7. fiiifii
+8. fiii
+
+max_backups = 4
+
+max_incremental_backups_per_full = 1
+
+1. f
+2. fi
+3. fif
+4. fifi
+5. fi
+
 ## Miscellaneous
 ### Storage class codes
 - STANDARD

--- a/README.md
+++ b/README.md
@@ -203,9 +203,15 @@ full backup (f)
 7.  f f f f f f f
 
 ## Max backups limit behaviour
-Once the max limit is reached, the program would remove the oldest chain. 
-If a single full exists, a new full would be created and all the past chain deleted.
-The end result would be a single full in this case.
+Once the max limit is reached, the limiter would:
+
+- If only fulls exist, removes the oldest full 
+- If a single full exists and a chain of incrementals after,
+it would delete the entire chain of incrementals and create a new incremental (squash)
+- If more than one full and inc chain exist:
+  - First pass, deletes the oldest inc chain
+  - Next run, deletes the oldest full (has no more dependants)
+
 
 ### Limit examples
 
@@ -230,7 +236,10 @@ max_incremental_backups_per_full = 1
 2. fi
 3. fif
 4. fifi
-5. fi
+5. ffi
+6. ffii
+7. fiii
+8. fi
 
 ## Miscellaneous
 ### Storage class codes

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -81,7 +81,7 @@ class JobTestsBase:
         # When
         self.job.restore()
         if self.encrypted_test:
-            out = load_key(self.job.filesystem, 'file:///test_key')
+            out = load_key(self.job.filesystem, 'file:///tmp/test_key')
             self.assertEqual(0, out.returncode, msg=out.stderr)
 
             out = mount_filesystem(self.job.filesystem)
@@ -107,7 +107,7 @@ class JobTestsBase:
         # When
         self.job.restore()
         if self.encrypted_test:
-            out = load_key(self.job.filesystem, 'file:///test_key')
+            out = load_key(self.job.filesystem, 'file:///tmp/test_key')
             self.assertEqual(0, out.returncode, msg=out.stderr)
 
             out = mount_filesystem(self.job.filesystem)
@@ -133,7 +133,7 @@ class JobTestsBase:
         # When
         self.job.restore()
         if self.encrypted_test:
-            out = load_key(self.job.filesystem, 'file:///test_key')
+            out = load_key(self.job.filesystem, 'file:///tmp/test_key')
             self.assertEqual(0, out.returncode, msg=out.stderr)
 
             out = mount_filesystem(self.job.filesystem)
@@ -184,7 +184,7 @@ class JobTestsBase:
         backups = self.job._backup_db.get_backup_times('inc')
         self.job.restore(backups[0])
         if self.encrypted_test:
-            out = load_key(self.job.filesystem, 'file:///test_key')
+            out = load_key(self.job.filesystem, 'file:///tmp/test_key')
             self.assertEqual(0, out.returncode, msg=out.stderr)
 
             out = mount_filesystem(self.job.filesystem)
@@ -213,7 +213,7 @@ class JobTestsBase:
         backups = self.job._backup_db.get_backup_times('full')
         self.job.restore(backups[0])
         if self.encrypted_test:
-            out = load_key(self.job.filesystem, 'file:///test_key')
+            out = load_key(self.job.filesystem, 'file:///tmp/test_key')
             self.assertEqual(0, out.returncode, msg=out.stderr)
 
             out = mount_filesystem(self.job.filesystem)
@@ -259,7 +259,7 @@ class JobTestsBase:
         # When
         self.job.restore(filesystem=self.filesystem_2)
         if self.encrypted_test:
-            out = load_key(self.filesystem_2, 'file:///test_key')
+            out = load_key(self.filesystem_2, 'file:///tmp/test_key')
             self.assertEqual(0, out.returncode, msg=out.stderr)
 
             out = mount_filesystem(self.filesystem_2)
@@ -356,7 +356,8 @@ class JobTestsBase:
         self.assertEqual(backups_full, backups_full_new)
 
         backups_inc_new = self.job._backup_db.get_backups(backup_type='inc')
-        self.assertEqual(backups_inc[1:], backups_inc_new)
+        # Can only nuke the last backup as the others have dependants 
+        self.assertEqual(backups_inc[:1], backups_inc_new)
 
         # When
         self.job._max_backups = 1
@@ -436,11 +437,11 @@ class JobTestsEncrypted(JobTestsBase, TestCase):
         self.test_file = f'/{self.job.filesystem}/test_file'
         self.test_data = str(list(range(100_000)))
 
-        with open('/test_key', 'w') as f:
+        with open('/tmp/test_key', 'w') as f:
             f.write('test_key')
         out = subprocess.run(
             ['zfs', 'create', '-o', 'encryption=on', '-o',
-             'keyformat=passphrase', '-o', 'keylocation=file:///test_key',
+             'keyformat=passphrase', '-o', 'keylocation=file:///tmp/test_key',
              self.job.filesystem],
             **SUBPROCESS_KWARGS
         )

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -314,25 +314,55 @@ class JobTestsBase:
         self.job._limit_backups()
 
         # Then
-        # Only the oldest incremental backup should be removed.
-        backups_full_new = self.job._backup_db.get_backups(backup_type='full')
-        self.assertEqual(backups_full, backups_full_new)
-
-        backups_inc_new = self.job._backup_db.get_backups(backup_type='inc')
-        self.assertEqual(backups_inc[1:], backups_inc_new)
-
-        # When
-        self.job._max_backups = 2
-        self.job._limit_backups()
-
-        # Then
-        # The oldest full backup should be removed.
+        # Only one full should remain as we deleted the oldest tree
         backups_full_new = self.job._backup_db.get_backups(backup_type='full')
         self.assertEqual(backups_full[1:], backups_full_new)
 
         backups_inc_new = self.job._backup_db.get_backups(backup_type='inc')
         self.assertEqual(backups_inc[1:], backups_inc_new)
 
+        # When
+        self.job._max_backups = 1
+        self.job._limit_backups()
+        # This config would force create a new full and remove the old chain
+
+        # Then
+        backups_full_new = self.job._backup_db.get_backups(backup_type='full')
+        self.assertEqual(1, len(backups_full_new))
+
+        # No inc should remain
+        backups_inc_new = self.job._backup_db.get_backups(backup_type='inc')
+        self.assertEqual(0, len(backups_inc_new))
+
+    
+    def test_limit_backups_remove_last_chain(self):
+        """ Test the backup limiter with 3 chains, deleting the oldest """
+
+        # Given
+        self.job._max_incremental_backups_per_full = 1
+
+        for _ in range(6):
+            self.job.start()
+
+        backups_full = self.job._backup_db.get_backups(backup_type='full')
+        self.assertEqual(3, len(backups_full))
+
+        backups_inc = self.job._backup_db.get_backups(backup_type='inc')
+        self.assertEqual(3, len(backups_inc))
+
+        # When
+        self.job._max_backups = 5
+        self.job._limit_backups()
+
+        # Then
+        backups_full_new = self.job._backup_db.get_backups(backup_type='full')
+        self.assertEqual(backups_full[1:], backups_full_new)
+
+        backups_inc_new = self.job._backup_db.get_backups(backup_type='inc')
+        self.assertEqual(backups_inc[1:], backups_inc_new)
+
+    
+    
     def test_limit_backups_one_full(self):
         """ Test the backup limiter when there's only one full backup. """
 
@@ -351,25 +381,15 @@ class JobTestsBase:
         self.job._limit_backups()
 
         # Then
-        # Only the oldest incremental backup should be removed.
+        # Since there is only one full and we reached the limit, 
+        # a new full is created and the old chain deleted
         backups_full_new = self.job._backup_db.get_backups(backup_type='full')
-        self.assertEqual(backups_full, backups_full_new)
+        self.assertEqual(1, len(backups_full_new))
 
         backups_inc_new = self.job._backup_db.get_backups(backup_type='inc')
-        # Can only nuke the last backup as the others have dependants
-        self.assertEqual(backups_inc[:1], backups_inc_new)
-
-        # When
-        self.job._max_backups = 1
-        self.job._limit_backups()
-
-        # Then
-        # Only the full backup should remain.
-        backups_full_new = self.job._backup_db.get_backups(backup_type='full')
-        self.assertEqual(backups_full, backups_full_new)
-
-        backups_inc_new = self.job._backup_db.get_backups(backup_type='inc')
+        # No incremental remains
         self.assertEqual(0, len(backups_inc_new))
+
 
     def test_limit_backups_all_full(self):
         """ Test the backup limiter when it's only full backups. """

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -356,7 +356,7 @@ class JobTestsBase:
         self.assertEqual(backups_full, backups_full_new)
 
         backups_inc_new = self.job._backup_db.get_backups(backup_type='inc')
-        # Can only nuke the last backup as the others have dependants 
+        # Can only nuke the last backup as the others have dependants
         self.assertEqual(backups_inc[:1], backups_inc_new)
 
         # When

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -334,7 +334,6 @@ class JobTestsBase:
         backups_inc_new = self.job._backup_db.get_backups(backup_type='inc')
         self.assertEqual(0, len(backups_inc_new))
 
-    
     def test_limit_backups_remove_last_chain(self):
         """ Test the backup limiter with 3 chains, deleting the oldest """
 
@@ -361,8 +360,6 @@ class JobTestsBase:
         backups_inc_new = self.job._backup_db.get_backups(backup_type='inc')
         self.assertEqual(backups_inc[1:], backups_inc_new)
 
-    
-    
     def test_limit_backups_one_full(self):
         """ Test the backup limiter when there's only one full backup. """
 
@@ -381,7 +378,7 @@ class JobTestsBase:
         self.job._limit_backups()
 
         # Then
-        # Since there is only one full and we reached the limit, 
+        # Since there is only one full and we reached the limit,
         # a new full is created and the old chain deleted
         backups_full_new = self.job._backup_db.get_backups(backup_type='full')
         self.assertEqual(1, len(backups_full_new))
@@ -389,7 +386,6 @@ class JobTestsBase:
         backups_inc_new = self.job._backup_db.get_backups(backup_type='inc')
         # No incremental remains
         self.assertEqual(0, len(backups_inc_new))
-
 
     def test_limit_backups_all_full(self):
         """ Test the backup limiter when it's only full backups. """

--- a/write_test_config.py
+++ b/write_test_config.py
@@ -8,6 +8,7 @@ config['DEFAULT'] = {
     'region': os.environ['AWS_DEFAULT_REGION'],
     'access_key': os.environ['AWS_ACCESS_KEY_ID'],
     'secret_key': os.environ['AWS_SECRET_ACCESS_KEY'],
+    'endpoint': os.environ['ENDPOINT'],
     'storage_class': 'STANDARD'
 }
 config['test-pool/test-filesystem'] = {

--- a/zfs_uploader/__init__.py
+++ b/zfs_uploader/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.9.0'
+__version__ = '0.10.0'
 
 BACKUP_DB_FILE = 'backup.db'
 DATETIME_FORMAT = '%Y%m%d_%H%M%S'

--- a/zfs_uploader/job.py
+++ b/zfs_uploader/job.py
@@ -18,7 +18,7 @@ from zfs_uploader.zfs import (destroy_filesystem, destroy_snapshot,
 
 KB = 1024
 MB = KB * KB
-S3_MAX_CONCURRENCY = 1
+S3_MAX_CONCURRENCY = 20
 
 
 class BackupError(Exception):
@@ -214,7 +214,6 @@ class ZFSjob:
         elif self._max_incremental_backups_per_full:
             backup_time = backup.backup_time
 
-            # TODO: Verify this
             dependants = [True if b.dependency == backup_time
                           else False for b in backups_inc]
 
@@ -331,7 +330,7 @@ class ZFSjob:
                 self._restore_snapshot(backup, filesystem)
 
         elif backup_type == 'inc':
-            # TODO: Walk the dependency tree and find the root which is a full. Restore in reverse traversal order until we reach the requested backup
+            # Walk the dependency tree and find the root which is a full. Restore in reverse traversal order until we reach the requested backup
             backup_tree = []
             backup_tree.append(backup) # Insert the current selected backup
             next = self._backup_db.get_backup(backup.dependency)
@@ -339,7 +338,6 @@ class ZFSjob:
                 backup_tree.append(next)
                 next = self._backup_db.get_backup(next.dependency)
             
-
             # Add the last one which is the full
             backup_tree.append(next)
 
@@ -460,8 +458,6 @@ class ZFSjob:
             File system to restore to. Defaults to the file system that the
             backup was taken from.
         """
-        import threading
-        print (threading.get_ident())
         
         backup_time = backup.backup_time
         backup_size = backup.backup_size

--- a/zfs_uploader/job.py
+++ b/zfs_uploader/job.py
@@ -211,15 +211,15 @@ class ZFSjob:
 
         # if we want incremental backups and multiple full backups
         elif self._max_incremental_backups_per_full:
-            backup_time = backup.backup_time
+            full_backup_time = backup.backup_time 
 
-            dependants = [True if b.dependency == backup_time
+            dependants = [True if b.dependency == full_backup_time
                           else False for b in backups_inc]
 
             if sum(dependants) >= self._max_incremental_backups_per_full:
                 self._backup_full()
             else:
-                self._backup_incremental(backup_time)
+                self._backup_incremental(incremental_or_full.backup_time)
 
         # if we want incremental backups and not multiple full backups
         else:

--- a/zfs_uploader/job.py
+++ b/zfs_uploader/job.py
@@ -167,7 +167,7 @@ class ZFSjob:
         self._cron = cron
         self._max_snapshots = max_snapshots
         self._max_backups = max_backups
-        self._max_incremental_backups_per_full = max_incremental_backups_per_full # noqa
+        self._max_incremental_backups_per_full = max_incremental_backups_per_full  # noqa
         self._storage_class = storage_class or 'STANDARD'
         self._max_multipart_parts = max_multipart_parts or 10000
         self._logger = logging.getLogger(__name__)
@@ -184,7 +184,7 @@ class ZFSjob:
                                'than or equal to 1."')
             sys.exit(1)
 
-        if max_incremental_backups_per_full and not max_incremental_backups_per_full >= 0: # noqa
+        if max_incremental_backups_per_full and not max_incremental_backups_per_full >= 0:  # noqa
             self._logger.error(f'filesystem={self._filesystem} '
                                'msg="max_incremental_backups_per_full must be '
                                'greater than or equal to 0."')
@@ -200,7 +200,6 @@ class ZFSjob:
         backup = backups_full[-1] if backups_full else None
         last_incremental = backups_inc[-1] if backups_inc else None
         incremental_or_full = last_incremental if last_incremental else backup
-        
 
         # if no full backup exists
         if backup is None:
@@ -330,14 +329,16 @@ class ZFSjob:
                 self._restore_snapshot(backup, filesystem)
 
         elif backup_type == 'inc':
-            # Walk the dependency tree and find the root which is a full. Restore in reverse traversal order until we reach the requested backup
+            # Walk the dependency tree and find the root which is a full.
+            # Restore in reverse traversal order until we reach the
+            # requested backup
             backup_tree = []
-            backup_tree.append(backup) # Insert the current selected backup
+            backup_tree.append(backup)  # Insert the current selected backup
             next = self._backup_db.get_backup(backup.dependency)
             while next.dependency:
                 backup_tree.append(next)
                 next = self._backup_db.get_backup(next.dependency)
-            
+
             # Add the last one which is the full
             backup_tree.append(next)
 
@@ -346,13 +347,11 @@ class ZFSjob:
             for b in backup_tree:
                 if b.backup_time in snapshots and filesystem is None:
                     self._logger.info(f'filesystem={self.filesystem} '
-                                    f'snapshot_name={b.backup_time} '
-                                    f's3_key={b.s3_key} '
-                                    'msg="Snapshot already exists."')
+                                      f'snapshot_name={b.backup_time} '
+                                      f's3_key={b.s3_key} '
+                                      'msg="Snapshot already exists."')
                 else:
                     self._restore_snapshot(b, filesystem)
-
-        
 
     def _backup_full(self):
         """ Create snapshot and upload full backup. """
@@ -458,7 +457,7 @@ class ZFSjob:
             File system to restore to. Defaults to the file system that the
             backup was taken from.
         """
-        
+
         backup_time = backup.backup_time
         backup_size = backup.backup_size
         filesystem = filesystem or backup.filesystem
@@ -564,15 +563,14 @@ class ZFSjob:
         deleted_count = 0
         for backup in backups:
             backup_time = backup.backup_time
-            backup_type = backup.backup_type
             s3_key = backup.s3_key
 
             dependants = any([True if b.dependency == backup_time
-                                  else False for b in backups])
+                              else False for b in backups])
             if dependants:
                 self._logger.info(f's3_key={s3_key} '
-                                    'msg="Backup has dependants. Not '
-                                    'deleting."')
+                                  'msg="Backup has dependants. Not '
+                                  'deleting."')
             else:
                 self._delete_backup(backup)
                 deleted_count += 1

--- a/zfs_uploader/job.py
+++ b/zfs_uploader/job.py
@@ -211,7 +211,7 @@ class ZFSjob:
 
         # if we want incremental backups and multiple full backups
         elif self._max_incremental_backups_per_full:
-            full_backup_time = backup.backup_time 
+            full_backup_time = backup.backup_time
 
             dependants = [True if b.dependency == full_backup_time
                           else False for b in backups_inc]

--- a/zfs_uploader/zfs.py
+++ b/zfs_uploader/zfs.py
@@ -76,7 +76,10 @@ def get_snapshot_send_size_inc(filesystem, snapshot_name_1, snapshot_name_2):
            f'{filesystem}@{snapshot_name_1}',
            f'{filesystem}@{snapshot_name_2}']
     out = subprocess.run(cmd, **SUBPROCESS_KWARGS)
-    return out.stdout.splitlines()[1].split()[1]
+    lines = out.stdout.splitlines()
+    if lines:
+        return lines[1].split()[1]
+    return None
 
 
 def open_snapshot_stream(filesystem, snapshot_name, mode):

--- a/zfs_uploader/zfs.py
+++ b/zfs_uploader/zfs.py
@@ -76,10 +76,7 @@ def get_snapshot_send_size_inc(filesystem, snapshot_name_1, snapshot_name_2):
            f'{filesystem}@{snapshot_name_1}',
            f'{filesystem}@{snapshot_name_2}']
     out = subprocess.run(cmd, **SUBPROCESS_KWARGS)
-    lines = out.stdout.splitlines()
-    if lines:
-        return lines[1].split()[1]
-    return None
+    return out.stdout.splitlines()[1].split()[1]
 
 
 def open_snapshot_stream(filesystem, snapshot_name, mode):


### PR DESCRIPTION
Hi @ddebeau,

Before this change, incremental backups where created based on a full. This caused increased storage and cost because the same deltas were stored N times, until a new full is created.

This change creates a proper chain from full to all the intermediate backups which allows only deltas to be uploaded. Cost should drop dramatically as we only keep what is necessary

The DB and dependency tree was already there, so this change is backwards compatible. Once deployed, new incs would be based on the latest snapshot